### PR TITLE
Reframe AI company essay

### DIFF
--- a/src/_posts/2026-05-25-company-os.md
+++ b/src/_posts/2026-05-25-company-os.md
@@ -153,10 +153,10 @@ and let the institution decide what survives.
 
 ## The Tradeoff Broke
 
-We did not do this to make the company feel more entrepreneurial. A year ago, we were not moving
-fast enough for the bets we wanted to win. But raw throughput is cheap to fake and easy to distrust.
-What mattered was whether we could raise standards, lower incident pressure, hold ownership, and
-still move faster.
+The bet was exactly that markets inside the company would make us more entrepreneurial without
+making us sloppier. A year ago, we were not moving fast enough for the bets we wanted to win. But
+raw throughput is cheap to fake and easy to distrust. What mattered was whether we could raise
+standards, lower incident pressure, hold ownership, and still move faster.
 
 Quality moved first. We called a platform stability Code Red because we were moving faster than our
 guardrails. That was central power doing its job: stopping the room, naming the cost, and making the

--- a/src/_posts/2026-05-25-company-os.md
+++ b/src/_posts/2026-05-25-company-os.md
@@ -27,7 +27,7 @@ and people data. A business that finally stops arguing back.
 
 Central planning feels like relief. That is the trap. Most AI management pitches are just CEO
 dashboards with better autocomplete. They promise a business that can be understood from one seat,
-which usually means it can only be changed from one seat too.
+then quietly make it changeable only from that seat.
 
 Central planning fails at local knowledge, not effort or intelligence. The center can set direction,
 fund the commons, and enforce standards. It cannot know enough, soon enough, to make every useful
@@ -52,10 +52,8 @@ AI does not just give the center better sight. It gives the edge a first move.
 The person closest to the problem used to have to gather the context, find the policy, write the
 pitch, wait for the meeting, and hope the idea survived translation.
 
-Now a complaint can become a draft; a diagnosis can become a script; a recurring failure can become
-a workflow someone else can steal. The person closest to the problem can inspect the logs, summarize
-the evidence, write the first version, and make the boundary visible before the next planning
-meeting.
+Now the first move is cheaper. A complaint can become a draft. A diagnosis can become a script. A
+recurring failure can become a workflow someone else can steal.
 
 The old alibi was coordination: missing tools, unclear mandate, no time, permission in another room.
 Real constraints still exist: access, time, incentives, authority. AI does not erase them. It makes
@@ -90,10 +88,10 @@ weekly ritual, and the SQL query quietly holding the business hostage.
 If useful truth has to climb the ladder before it can matter, the company has already chosen
 latency: politics over truth.
 
-Central planning is often more efficient this week. One person settles the debate, picks the tool,
-collapses the option space, and forces motion. The tax arrives later: people learn to frame work for
-approval, not impact. Eventually the company fills with permission queues. People get good at
-serving the machine and worse at changing it.
+Central planning can win the week. One person settles the debate, picks the tool, collapses the
+option space, and forces motion. The tax arrives later: people learn to frame work for approval, not
+impact. Eventually the company fills with permission queues. People get good at serving the machine
+and bad at changing it.
 
 Someone in support knows the path: which logs matter, which project to open, which tenant context
 changes the answer, how to rerun a failed audience export without making the failure worse. That
@@ -129,8 +127,8 @@ Make the tax explicit. Maintain the paths. Kill duplicates. Protect boring work.
 evidence becomes public performance. Markets do not remove management; they expose the work
 management was already hiding.
 
-The company has to make truth-seeking cheaper than the political move: show receipts, name the
-owner, price the risk, and make polished theater too heavy to carry.
+The company has to make truth-seeking cheaper than politics: show receipts, name the owner, price
+the risk, and make polished theater too heavy to carry.
 
 At GrowthLoop, Gaia and Grimoire split the job. Gaia turns local fixes into shared supply. Grimoire
 turns that supply into named bets: owner, review, funding, and a way to die.
@@ -145,51 +143,15 @@ carrying work because nobody had called it dead, and leaders treating fear and a
 instead of work.
 
 So the company moved capital. We killed most of those bets, moved people to better ones, and made
-the standard explicit: a lead is not done when they report resistance. They are accountable for
-turning resistance into a decision.
+the standard explicit: a lead is not done when they report resistance. They own turning resistance
+into a decision.
 
 That is the [directed chaos](/blog/directed-chaos/) bargain: build locally, face standards publicly,
 and let the institution decide what survives.
 
-## The Tradeoff Broke
-
-The bet was that the old tradeoff was fake: more local motion did not have to mean more damage. A
-year ago, we were not moving fast enough for the bets we wanted to win. But raw throughput is cheap
-to fake and easy to distrust. What mattered was whether we could raise standards, lower incident
-pressure, hold ownership, and still move faster.
-
-Quality moved first. We called a platform stability Code Red because we were moving faster than our
-guardrails. That was central power doing its job: stopping the room, naming the cost, and making the
-problem impossible to route around.
-
-Then the operational measures moved the right way. High-urgency incidents were cut in half.
-Resolution time fell from four days to less than one. Pager acknowledgements went from a coin flip
-to nearly automatic.
-
-Work stayed attached to real projects instead of drifting into clever, ownerless churn. More output
-is not progress if nobody can explain what bet it serves.
-
-Throughput rose too. A year ago, roughly 30 engineering ICs shipped about 700 merged PRs per
-quarter. Now a smaller team ships about 1,900, while incident pressure has fallen.
-
-PR count is easy to fake. Slice work smaller, ship cosmetic churn, stay safe. I only care here
-because the obvious failure mode did not show up: incidents fell, recovery sped up, ownership stayed
-attached, and stale work got harder to carry.
-
-More work arrived with the pain that caused it, the person carrying it, and the artifact others
-could reuse. A project could not stay alive just because it sounded important. A local fix could not
-stay invisible just because it started small.
-
-Most companies get slower when they raise standards. They get procedural, political, and
-approval-bound. The machine learns to call friction maturity.
-
-We got faster because AI made local work cheaper to package, ship, and reuse, and the company gave
-that work a path: Gaia for supply, Grimoire for ownership and consequence, the center for bets the
-market could not yet price.
-
 ## Founder Power Must Leave Artifacts
 
-The point is not to abolish the center. Some bets still belong there: strategy, taste, culture,
+That bargain still needs a center. Some bets still belong there: strategy, taste, culture,
 standards, incentives, safety, budgets, existential risk, and the commons no local team would fund
 early enough.
 
@@ -206,21 +168,55 @@ was one of those founder bets. The category did not exist as a clean budget line
 could prove demand yet. The center spent trust to name and fund it, then forced the bet back through
 standards, ownership, and consequence.
 
-That power earns its place only when it comes back with receipts: risk named, owner assigned, budget
+That power earns its place when it comes back with receipts: risk named, owner assigned, budget
 visible, kill criteria stated, review date set. Founder intervention becomes central planning when
-it is constant, hidden, or detached from local evidence. Intervene loudly, own the bet, make the
+it is constant, hidden, or detached from local evidence. Intervene loudly. Own the bet. Make the
 cost visible. The best use of concentrated power is to make more of the company powerful.
 
 Power does not get better by pretending it is harmless. It gets better when reality has enough
 [independent paths](https://blog.cosmos-institute.org/p/when-decentralization-fails) back into the
 room that power cannot quietly grade its own work.
 
+## The Tradeoff Broke
+
+The old tradeoff was fake: more local motion did not have to mean more damage. A year ago, the bets
+in front of us needed a faster company. Speed was not a preference. It was the constraint. But raw
+throughput is cheap to fake and easy to distrust; the question was whether we could raise standards,
+lower incident pressure, keep ownership attached, and move faster anyway.
+
+Quality had to move first. We called a platform stability Code Red because speed had outrun the
+guardrails. That was central power doing its job: stopping the room, naming the cost, and making the
+problem impossible to route around.
+
+Then the failures fell. High-urgency incidents were cut in half. Resolution time fell from four days
+to less than one. Pager acknowledgements went from a coin flip to nearly automatic.
+
+Then shipping caught up. A year ago, roughly 30 engineering ICs merged about 700 PRs per quarter.
+Now a smaller team ships about 1,900, while incident pressure has fallen.
+
+PR count is easy to fake. Slice work smaller, ship cosmetic churn, stay safe. I only care here
+because the obvious failure mode did not show up: incidents fell, recovery sped up, ownership stayed
+attached, and stale work got harder to carry.
+
+The important change was not 1,900 PRs. It was the shape of the work. More of it arrived with the
+pain that caused it, the person carrying it, and the artifact others could reuse. A project could
+not stay alive just because it sounded important. A local fix could not stay invisible just because
+it started small.
+
+Most companies get slower when they raise standards. They get procedural, political, and
+approval-bound. The machine learns to call friction maturity.
+
+We got faster because AI made local work cheaper to package, ship, and reuse, and because we built
+the institutions to catch it: Gaia for supply, Grimoire for ownership and consequence, the center
+for bets the market could not yet price.
+
 ## The Company Learns
 
-AI will flood companies with local attempts. Most organizations will make the flood legible to
-executives: dashboards, approvals, summaries, and prettier permission systems.
+AI will flood every company with local attempts. Weak companies will pipe them upward into
+dashboards, approvals, summaries, and prettier permission systems.
 
-The companies that learn fastest will force those attempts to answer: who owns them, what they cost,
-who uses them, what changed, and when they die.
+Strong companies will make them compete: pain becomes a bid, the bid becomes an artifact, the
+artifact earns adoption, and adoption forces a decision.
 
-The company that wins is not the one that sees more. It is the one that makes truth consequential.
+The company that wins is not the one that sees more. It is the one where truth moves money, people,
+and power.

--- a/src/_posts/2026-05-25-company-os.md
+++ b/src/_posts/2026-05-25-company-os.md
@@ -72,9 +72,9 @@ a company using AI well, the person who matters is the one willing to answer for
 Before adding headcount, platform work, or another ritual, ask the hard question: did someone close
 to the problem use AI and still hit a real boundary?
 
-People owe the company attempts, not just explanations, but only inside a real bargain. Leaders owe
-access, time, authority, and real stakes. If they ask for agency while withholding those, they are
-not building a market. They are laundering extra work through ambition.
+People owe the company attempts, not just explanations. Leaders owe the conditions that make
+attempts honest: access, time, authority, and real stakes. Ask for agency while withholding those
+and you are not building a market. You are laundering extra work through ambition.
 
 This makes central planning more expensive, not less. Managers who only route permission become
 delay. ICs who only diagnose run out of cover. Companies that cannot absorb local building turn AI
@@ -125,9 +125,9 @@ The currency is not enthusiasm. It is pulled usage, owner time, budget, reduced 
 behavior. Praise is not demand. A project with no owner is not a bet. A tool that saves one team by
 pushing its cost onto three others has not cleared the market. It has exported pain.
 
-This is not free. Someone has to maintain the paths, kill duplicates, protect boring work, and
-notice when public evidence becomes public performance. The claim is not that markets remove
-management. It is that they make the cost visible early enough to manage.
+Make the tax explicit. Maintain the paths. Kill duplicates. Protect boring work. Notice when public
+evidence becomes public performance. Markets do not remove management; they expose the work
+management was already hiding.
 
 The company has to make truth-seeking cheaper than the political move: show receipts, name the
 owner, price the risk, and make polished theater too heavy to carry.
@@ -153,10 +153,10 @@ and let the institution decide what survives.
 
 ## The Tradeoff Broke
 
-The test was not whether this made the company feel more entrepreneurial. A year ago, we were not
-moving fast enough for the bets we wanted to win. But raw throughput is cheap to fake and easy to
-distrust. What mattered was whether we could raise standards, lower incident pressure, hold
-ownership, and still move faster.
+We did not do this to make the company feel more entrepreneurial. A year ago, we were not moving
+fast enough for the bets we wanted to win. But raw throughput is cheap to fake and easy to distrust.
+What mattered was whether we could raise standards, lower incident pressure, hold ownership, and
+still move faster.
 
 Quality moved first. We called a platform stability Code Red because we were moving faster than our
 guardrails. That was central power doing its job: stopping the room, naming the cost, and making the
@@ -172,9 +172,9 @@ is not progress if nobody can explain what bet it serves.
 Throughput rose too. A year ago, roughly 30 engineering ICs shipped about 700 merged PRs per
 quarter. Now a smaller team ships about 1,900, while incident pressure has fallen.
 
-PR count is a dirty metric on its own. It is easy to game with smaller slices, cosmetic churn, and
-safer work. I only care here because the obvious failure mode did not show up: incidents fell,
-recovery sped up, ownership stayed attached, and stale work got harder to carry.
+PR count is easy to fake. Slice work smaller, ship cosmetic churn, stay safe. I only care here
+because the obvious failure mode did not show up: incidents fell, recovery sped up, ownership stayed
+attached, and stale work got harder to carry.
 
 More work arrived with the pain that caused it, the person carrying it, and the artifact others
 could reuse. A project could not stay alive just because it sounded important. A local fix could not
@@ -220,7 +220,7 @@ room that power cannot quietly grade its own work.
 AI will flood companies with local attempts. Most organizations will make the flood legible to
 executives: dashboards, approvals, summaries, and prettier permission systems.
 
-The companies that learn fastest will make those attempts accountable: who owns them, what they
-cost, who uses them, what changed, and when they die.
+The companies that learn fastest will force those attempts to answer: who owns them, what they cost,
+who uses them, what changed, and when they die.
 
 The company that wins is not the one that sees more. It is the one that makes truth consequential.

--- a/src/_posts/2026-05-25-company-os.md
+++ b/src/_posts/2026-05-25-company-os.md
@@ -27,7 +27,7 @@ and people data. A business that finally stops arguing back.
 
 Central planning feels like relief. That is the trap. Most AI management pitches are just CEO
 dashboards with better autocomplete. They promise a business that can be understood from one seat,
-which usually means a business that has to be changed from one seat too.
+which usually means it can only be changed from one seat too.
 
 Central planning fails at local knowledge, not effort or intelligence. The center can set direction,
 fund the commons, and enforce standards. It cannot know enough, soon enough, to make every useful
@@ -36,8 +36,10 @@ move from above.
 Use AI to strengthen central planning and the company will look modern while getting slower. Use it
 to make local work compete and the company compounds.
 
-A free market inside a company is not the absence of management. It is how local work faces demand,
-price, and consequence before politics can protect it.
+Inside a company, a free market is engineered. The center still chooses the game, funds the commons,
+sets standards, and protects the long-term bet. But useful work needs pressure before politics can
+protect it: pain becomes the bid, the artifact becomes supply, adoption proves demand, owner time
+and budget set the price, and review decides what gets funded, spread, or killed.
 
 A better company does not make headquarters omniscient. It turns local pain into work others can
 pull: a draft, a script, a path, a workflow. The useful work travels. The rest has to earn another
@@ -65,14 +67,14 @@ should fix this" into "here is the first version, here is what it proves, and he
 broke."
 
 AI can draft the move. It cannot stand behind it. Attempts get cheap; ownership keeps them real. In
-an AI company, the person who matters is the one willing to answer for what the work does.
+a company using AI well, the person who matters is the one willing to answer for what the work does.
 
-Before adding headcount, platform work, or another ritual, ask the hard question: did a sharp owner
-with AI hit a real boundary?
+Before adding headcount, platform work, or another ritual, ask the hard question: did someone close
+to the problem use AI and still hit a real boundary?
 
-People owe the company attempts, not just explanations. Leaders owe people access, time, authority,
-and real stakes. If they withhold those, they own the bottleneck. Both sides lose the right to hide
-inside ambiguity.
+People owe the company attempts, not just explanations, but only inside a real bargain. Leaders owe
+access, time, authority, and real stakes. If they ask for agency while withholding those, they are
+not building a market. They are laundering extra work through ambition.
 
 This makes central planning more expensive, not less. Managers who only route permission become
 delay. ICs who only diagnose run out of cover. Companies that cannot absorb local building turn AI
@@ -103,20 +105,15 @@ a customer workaround, a ritual made less stupid. First it saves one person's we
 else steals it, changes it, and makes it sturdier. That is when it becomes supply.
 
 Before Gaia, that support memory usually became a Slack tip or a document: useful once, hard to
-reuse, easy to lose. Gaia is our shared repo for that work: scripts, prompts, workflows, paths, and
-fixes other teams can pull instead of rediscovering. It turns the path into something a person can
-inspect, run, change, and improve. When that work showed up in demos, demand pulled it forward
-because the pain was already theirs.
+reuse, easy to lose. Slack is still where the bruise announces itself: loud, public, messy, and
+weirdly efficient. But a company cannot inherit a Slack thread.
 
-A bot helps, but it cannot be the only home for company memory. If that memory only lives behind a
-bot, people become petitioners: they ask the machine, get unstuck, and leave the path invisible for
-the next person. A bot can answer the question. Gaia makes the answer inheritable.
+Gaia is our shared repo for those runnable objects: scripts, prompts, workflows, paths, and fixes
+other teams can inspect, pull, change, and improve. A bot can answer in the moment. Gaia makes the
+path inheritable.
 
-Slack is still loud, public, messy, and weirdly efficient at discovery. Gaia matters because useful
-fixes need goods, not just conversation.
-
-Work has to travel before it is blessed. No owner, no adoption path, no evidence, no kill rule: just
-noise with better mythology.
+Work has to travel before it is blessed. If there is no owner, no adoption path, no proof, and no
+way to die, it is not a market. It is noise with better mythology.
 
 ## Free Markets Need Institutions
 
@@ -128,20 +125,24 @@ The currency is not enthusiasm. It is pulled usage, owner time, budget, reduced 
 behavior. Praise is not demand. A project with no owner is not a bet. A tool that saves one team by
 pushing its cost onto three others has not cleared the market. It has exported pain.
 
+This is not free. Someone has to maintain the paths, kill duplicates, protect boring work, and
+notice when public evidence becomes public performance. The claim is not that markets remove
+management. It is that they make the cost visible early enough to manage.
+
 The company has to make truth-seeking cheaper than the political move: show receipts, name the
 owner, price the risk, and make polished theater too heavy to carry.
 
-At GrowthLoop, Gaia and Grimoire split the job. Gaia lets local work appear, spread, mutate, and
-become shared machinery. Grimoire makes that work visible, owned, reviewed, funded, killed, and
-remembered. Pain becomes a version others can use; use creates evidence.
+At GrowthLoop, Gaia and Grimoire split the job. Gaia turns local fixes into shared supply. Grimoire
+turns that supply into named bets: owner, review, funding, and a way to die.
 
 Every six weeks, Grimoire turns the portfolio into a docket: owners, movement, stalls, costs,
 evidence, and what changed. The owner has to stand in public with the facts while there is still
-time to change the bet. Grimoire does not just show reality. It makes the company touch it.
+time to change the bet. Grimoire does not just show reality. It forces the company to decide while
+the facts still matter.
 
-In one recent review, the room could not hide behind updates. The record showed which bets had gone
-cold, which owners were carrying work out of habit, and which leaders were treating fear and
-ambiguity as weather instead of work.
+In one recent review, the record made the evasions visible: cold bets wearing active names, owners
+carrying work because nobody had called it dead, and leaders treating fear and ambiguity as weather
+instead of work.
 
 So the company moved capital. We killed most of those bets, moved people to better ones, and made
 the standard explicit: a lead is not done when they report resistance. They are accountable for
@@ -149,6 +150,42 @@ turning resistance into a decision.
 
 That is the [directed chaos](/blog/directed-chaos/) bargain: build locally, face standards publicly,
 and let the institution decide what survives.
+
+## The Tradeoff Broke
+
+The test was not whether this made the company feel more entrepreneurial. A year ago, we were not
+moving fast enough for the bets we wanted to win. But raw throughput is cheap to fake and easy to
+distrust. What mattered was whether we could raise standards, lower incident pressure, hold
+ownership, and still move faster.
+
+Quality moved first. We called a platform stability Code Red because we were moving faster than our
+guardrails. That was central power doing its job: stopping the room, naming the cost, and making the
+problem impossible to route around.
+
+Then the operational measures moved the right way. High-urgency incidents were cut in half.
+Resolution time fell from four days to less than one. Pager acknowledgements went from a coin flip
+to nearly automatic.
+
+Work stayed attached to real projects instead of drifting into clever, ownerless churn. More output
+is not progress if nobody can explain what bet it serves.
+
+Throughput rose too. A year ago, roughly 30 engineering ICs shipped about 700 merged PRs per
+quarter. Now a smaller team ships about 1,900, while incident pressure has fallen.
+
+PR count is a dirty metric on its own. It is easy to game with smaller slices, cosmetic churn, and
+safer work. I only care here because the obvious failure mode did not show up: incidents fell,
+recovery sped up, ownership stayed attached, and stale work got harder to carry.
+
+More work arrived with the pain that caused it, the person carrying it, and the artifact others
+could reuse. A project could not stay alive just because it sounded important. A local fix could not
+stay invisible just because it started small.
+
+Most companies get slower when they raise standards. They get procedural, political, and
+approval-bound. The machine learns to call friction maturity.
+
+We got faster because AI made local work cheaper to package, ship, and reuse, and the company gave
+that work a path: Gaia for supply, Grimoire for ownership and consequence, the center for bets the
+market could not yet price.
 
 ## Founder Power Must Leave Artifacts
 
@@ -165,9 +202,9 @@ Those are war powers. Use them. The failure is when the emergency becomes the co
 The failure is not concentrated power. The failure is power that leaves no artifact.
 
 [Compound Marketing Engine](https://www.growthloop.com/press/growthloop-unveils-its-compound-marketing-engine)
-was one of those founder bets: too early for any local team to justify, important enough for the
-center to fund anyway. It gave the company a name and funding path for the category, then forced the
-bet back through standards, ownership, and consequence.
+was one of those founder bets. The category did not exist as a clean budget line, so no local team
+could prove demand yet. The center spent trust to name and fund it, then forced the bet back through
+standards, ownership, and consequence.
 
 That power earns its place only when it comes back with receipts: risk named, owner assigned, budget
 visible, kill criteria stated, review date set. Founder intervention becomes central planning when
@@ -178,43 +215,12 @@ Power does not get better by pretending it is harmless. It gets better when real
 [independent paths](https://blog.cosmos-institute.org/p/when-decentralization-fails) back into the
 room that power cannot quietly grade its own work.
 
-## The Tradeoff Broke
-
-A year ago, we were not moving fast enough for the bets we wanted to win. But raw throughput is
-cheap to fake and easy to distrust. The test was whether we could raise standards, lower incident
-pressure, hold ownership, and still move faster.
-
-Quality moved first. Early in this journey, we called a platform stability Code Red because we were
-moving faster than our guardrails. That was central power doing its job: stopping the room, naming
-the cost, and making the problem impossible to route around.
-
-Then the numbers moved the right way. High-urgency incidents were cut in half. Resolution time fell
-from four days to less than one. Pager acknowledgements went from a coin flip to nearly automatic.
-
-Ownership held. The extra work still attached to real projects instead of drifting into clever,
-ownerless churn. More output is not progress if nobody can explain what bet it serves.
-
-Throughput rose too. A year ago, roughly 30 engineering ICs shipped about 700 merged PRs per
-quarter. Now a smaller team ships about 1,900, while incident pressure has fallen.
-
-PR count only matters when the damage does not rise with it. Here, stale work got harder to carry.
-More work arrived with the pain that caused it, the owner carrying it, the artifact others could
-reuse, and the evidence it had to survive. A project could not stay alive just because it sounded
-important. A local fix could not stay invisible just because it started small.
-
-Most companies get slower when they raise standards. They get procedural, political, and
-approval-bound. The machine learns to call friction maturity.
-
-We got faster because AI made local work cheaper to package, ship, and reuse, and the company gave
-that work a path: Gaia for supply, Grimoire for ownership and consequence, the center for bets the
-market could not yet price.
-
 ## The Company Learns
 
-AI will flood companies with local attempts. Most organizations will absorb them into dashboards,
-approvals, executive synthesis, and prettier permission systems.
+AI will flood companies with local attempts. Most organizations will make the flood legible to
+executives: dashboards, approvals, summaries, and prettier permission systems.
 
-The companies that learn fastest will do the opposite. They will make local work survive contact
-with reality: who owns it, what it costs, what it changes, and when it dies.
+The companies that learn fastest will make those attempts accountable: who owns them, what they
+cost, who uses them, what changed, and when they die.
 
 The company that wins is not the one that sees more. It is the one that makes truth consequential.

--- a/src/_posts/2026-05-25-company-os.md
+++ b/src/_posts/2026-05-25-company-os.md
@@ -8,7 +8,7 @@ permalink: /blog/company-os/
 categories: ["Leadership"]
 description:
   The next great companies will not use AI to make central planning work. They will turn local truth
-  into bids, evidence, owners, and decisions.
+  into bids, proof, owners, and decisions.
 pull_quote: >
   Use AI to strengthen central planning and the company will look modern while getting slower. Use
   it to make local work compete and the company compounds.
@@ -18,11 +18,12 @@ image: "/assets/img/company-os.jpg"
 
 Founders are not short on data. They are short on unedited reality.
 
+The modern executive stack is full of softeners: dashboards, summaries, meetings, AI briefs. Each
+promises reality without the bruise.
+
 Vendors sell them the oldest executive fantasy with a new AI budget: central planning that finally
 works. One room, one map, one AI chief of staff stitched across Slack, docs, CRM, tickets, metrics,
-and people data. A business that finally stops arguing back. The pitch works because the pain is
-real. Each function carries its own map. Meetings sand off the hard parts. Status arrives late,
-pre-defended, and pre-softened.
+and people data. A business that finally stops arguing back.
 
 Central planning feels like relief. That is the trap. Most AI management pitches are just CEO
 dashboards with better autocomplete. They promise a business that can be understood from one seat,
@@ -35,8 +36,12 @@ move from above.
 Use AI to strengthen central planning and the company will look modern while getting slower. Use it
 to make local work compete and the company compounds.
 
+A free market inside a company is not the absence of management. It is how local work faces demand,
+price, and consequence before politics can protect it.
+
 A better company does not make headquarters omniscient. It turns local pain into work others can
-pull: a draft, a script, a path, a workflow. Demand finds what is useful. Evidence moves capital.
+pull: a draft, a script, a path, a workflow. The useful work travels. The rest has to earn another
+day.
 
 ## AI Makes Agency Auditable
 
@@ -62,11 +67,11 @@ broke."
 AI can draft the move. It cannot stand behind it. Attempts get cheap; ownership keeps them real. In
 an AI company, the person who matters is the one willing to answer for what the work does.
 
-Before adding headcount, meetings, platform work, or another ritual, the first question should be
-brutal: did a sharp owner with AI hit a real boundary, or did everyone just reach for an excuse?
+Before adding headcount, platform work, or another ritual, ask the hard question: did a sharp owner
+with AI hit a real boundary?
 
 People owe the company attempts, not just explanations. Leaders owe people access, time, authority,
-and consequence. If they withhold those, they own the bottleneck. Both sides lose the right to hide
+and real stakes. If they withhold those, they own the bottleneck. Both sides lose the right to hide
 inside ambiguity.
 
 This makes central planning more expensive, not less. Managers who only route permission become
@@ -98,9 +103,10 @@ a customer workaround, a ritual made less stupid. First it saves one person's we
 else steals it, changes it, and makes it sturdier. That is when it becomes supply.
 
 Before Gaia, that support memory usually became a Slack tip or a document: useful once, hard to
-reuse, easy to lose. Gaia is our executable company memory. It turns the path into something a
-person can pull, inspect, run, change, and improve. When that work showed up in demos, demand pulled
-it forward because the pain was already theirs.
+reuse, easy to lose. Gaia is our shared repo for that work: scripts, prompts, workflows, paths, and
+fixes other teams can pull instead of rediscovering. It turns the path into something a person can
+inspect, run, change, and improve. When that work showed up in demos, demand pulled it forward
+because the pain was already theirs.
 
 A bot helps, but it cannot be the only home for company memory. If that memory only lives behind a
 bot, people become petitioners: they ask the machine, get unstuck, and leave the path invisible for
@@ -114,16 +120,15 @@ noise with better mythology.
 
 ## Free Markets Need Institutions
 
-Free markets inside companies are dangerous. Without institutions, they reward whoever can route
-around whom: charisma passing for demand, demos passing for products, Slack praise passing for
-adoption, motion passing for learning. Assume the market will be gamed. Build until gaming gets
-expensive.
+Free markets inside companies are dangerous. Without institutions, they become markets for heat: the
+loud demo, the charismatic owner, the Slack thread that feels like demand because everyone can see
+it. Assume the market will be gamed. Build until gaming gets expensive.
 
 The currency is not enthusiasm. It is pulled usage, owner time, budget, reduced pain, and changed
 behavior. Praise is not demand. A project with no owner is not a bet. A tool that saves one team by
 pushing its cost onto three others has not cleared the market. It has exported pain.
 
-The company has to make truth-seeking cheaper than the political move: show the evidence, name the
+The company has to make truth-seeking cheaper than the political move: show receipts, name the
 owner, price the risk, and make polished theater too heavy to carry.
 
 At GrowthLoop, Gaia and Grimoire split the job. Gaia lets local work appear, spread, mutate, and
@@ -185,7 +190,6 @@ the cost, and making the problem impossible to route around.
 
 Then the numbers moved the right way. High-urgency incidents were cut in half. Resolution time fell
 from four days to less than one. Pager acknowledgements went from a coin flip to nearly automatic.
-Pain was becoming harder to hide and faster to fix.
 
 Ownership held. The extra work still attached to real projects instead of drifting into clever,
 ownerless churn. More output is not progress if nobody can explain what bet it serves.
@@ -193,13 +197,10 @@ ownerless churn. More output is not progress if nobody can explain what bet it s
 Throughput rose too. A year ago, roughly 30 engineering ICs shipped about 700 merged PRs per
 quarter. Now a smaller team ships about 1,900, while incident pressure has fallen.
 
-PR count only matters when the damage does not rise with it. Here, ownership stayed attached and
-stale work got harder to carry. The lazy explanation stops fitting.
-
+PR count only matters when the damage does not rise with it. Here, stale work got harder to carry.
 More work arrived with the pain that caused it, the owner carrying it, the artifact others could
-reuse, and the evidence it had to survive. That changed what the company could pretend not to know.
-A project could not stay alive just because it sounded important. A local fix could not stay
-invisible just because it started small.
+reuse, and the evidence it had to survive. A project could not stay alive just because it sounded
+important. A local fix could not stay invisible just because it started small.
 
 Most companies get slower when they raise standards. They get procedural, political, and
 approval-bound. The machine learns to call friction maturity.
@@ -210,15 +211,10 @@ market could not yet price.
 
 ## The Company Learns
 
-AI will flood companies with local attempts. Most organizations will respond by strengthening
-central planning: more dashboards, more approvals, more executive synthesis, more beautiful
-permission systems.
+AI will flood companies with local attempts. Most organizations will absorb them into dashboards,
+approvals, executive synthesis, and prettier permission systems.
 
-The companies that learn fastest do the opposite. They let local work compete, then discipline the
-market with institutions strong enough to kill what does not earn its place.
-
-That is the core bet. AI will make attempts cheap. Central planning will try to absorb them. The
-next great companies will make those attempts prove who owns them, what they cost, and what they
-change.
+The companies that learn fastest will do the opposite. They will make local work survive contact
+with reality: who owns it, what it costs, what it changes, and when it dies.
 
 The company that wins is not the one that sees more. It is the one that makes truth consequential.

--- a/src/_posts/2026-05-25-company-os.md
+++ b/src/_posts/2026-05-25-company-os.md
@@ -32,15 +32,11 @@ Central planning fails at local knowledge, not effort or intelligence. The cente
 fund the commons, and enforce standards. It cannot know enough, soon enough, to make every useful
 move from above.
 
-This is the bet: local knowledge should become action before it becomes status, and useful action
-should face evidence before it becomes politics.
-
 Use AI to strengthen central planning and the company will look modern while getting slower. Use it
 to make local work compete and the company compounds.
 
 A better company does not make headquarters omniscient. It turns local pain into work others can
 pull: a draft, a script, a path, a workflow. Demand finds what is useful. Evidence moves capital.
-Not a prettier permission system. A company that can be changed by the truth it already contains.
 
 ## AI Makes Agency Auditable
 
@@ -55,8 +51,8 @@ the evidence, write the first version, and make the boundary visible before the 
 meeting.
 
 The old alibi was coordination: missing tools, unclear mandate, no time, permission in another room.
-Real constraints still exist: access, time, incentives, authority. AI does not erase those
-constraints. It makes the alibi auditable: show the draft, show the attempt, show the boundary.
+Real constraints still exist: access, time, incentives, authority. AI does not erase them. It makes
+them auditable.
 
 Inside a company, a bid is not a complaint, a ticket, or a strategy doc. It is an attempt with
 evidence attached: the script, the workflow, the customer path, the boundary hit. AI turns "someone
@@ -64,8 +60,7 @@ should fix this" into "here is the first version, here is what it proves, and he
 broke."
 
 AI can draft the move. It cannot stand behind it. Attempts get cheap; ownership keeps them real. In
-an AI company, the person who matters is the one willing to answer for what the work does. If no one
-will own the consequence, the company should treat the bid as noise.
+an AI company, the person who matters is the one willing to answer for what the work does.
 
 Before adding headcount, meetings, platform work, or another ritual, the first question should be
 brutal: did a sharp owner with AI hit a real boundary, or did everyone just reach for an excuse?
@@ -77,10 +72,6 @@ inside ambiguity.
 This makes central planning more expensive, not less. Managers who only route permission become
 delay. ICs who only diagnose run out of cover. Companies that cannot absorb local building turn AI
 into theater.
-
-If AI gives everyone tools to build and the company still routes every useful move through the
-center, it teaches people to wait. It turns builders into factory workers with better equipment:
-faster with inputs, weaker at owning outcomes.
 
 ## Free Markets Find the Bruise
 
@@ -119,8 +110,7 @@ Slack is still loud, public, messy, and weirdly efficient at discovery. Gaia mat
 fixes need goods, not just conversation.
 
 Work has to travel before it is blessed. No owner, no adoption path, no evidence, no kill rule: just
-noise with better mythology. Markets do not stay honest on their own. They need a place to make
-bids, a public trail of who pulled them, an owner, a review cadence, a kill rule, and a budget path.
+noise with better mythology.
 
 ## Free Markets Need Institutions
 
@@ -128,10 +118,6 @@ Free markets inside companies are dangerous. Without institutions, they reward w
 around whom: charisma passing for demand, demos passing for products, Slack praise passing for
 adoption, motion passing for learning. Assume the market will be gamed. Build until gaming gets
 expensive.
-
-Not laissez-faire. Attention, ownership, and capital are scarce. Price them with evidence, or
-pretend the center can see every bruise first. Institutions price what theater avoids: who owns it,
-who uses it, what it costs, what got worse, and when it dies.
 
 The currency is not enthusiasm. It is pulled usage, owner time, budget, reduced pain, and changed
 behavior. Praise is not demand. A project with no owner is not a bet. A tool that saves one team by
@@ -163,8 +149,7 @@ and let the institution decide what survives.
 
 The point is not to abolish the center. Some bets still belong there: strategy, taste, culture,
 standards, incentives, safety, budgets, existential risk, and the commons no local team would fund
-early enough. A market inside a company is not the absence of power. It is a way to make power
-answer to evidence.
+early enough.
 
 Founder power belongs here too. Some bets have no natural owner yet. Founders can absorb risk, spend
 trust, fund the commons, and say, "We are moving now," before the market has enough evidence to
@@ -188,9 +173,6 @@ Power does not get better by pretending it is harmless. It gets better when real
 [independent paths](https://blog.cosmos-institute.org/p/when-decentralization-fails) back into the
 room that power cannot quietly grade its own work.
 
-The market should discover. Leaders should intervene when they must. Both should have to answer to
-evidence.
-
 ## The Tradeoff Broke
 
 A year ago, we were not moving fast enough for the bets we wanted to win. But raw throughput is
@@ -211,14 +193,13 @@ ownerless churn. More output is not progress if nobody can explain what bet it s
 Throughput rose too. A year ago, roughly 30 engineering ICs shipped about 700 merged PRs per
 quarter. Now a smaller team ships about 1,900, while incident pressure has fallen.
 
-PR count only matters when the damage does not rise with it. Here, incidents fell, resolution got
-faster, ownership stayed attached, and stale work got harder to carry. The lazy explanation stops
-fitting.
+PR count only matters when the damage does not rise with it. Here, ownership stayed attached and
+stale work got harder to carry. The lazy explanation stops fitting.
 
-The important part was the trail. More work arrived with the pain that caused it, the owner carrying
-it, the artifact others could reuse, and the evidence it had to survive. That changed what the
-company could pretend not to know. A project could not stay alive just because it sounded important.
-A local fix could not stay invisible just because it started small.
+More work arrived with the pain that caused it, the owner carrying it, the artifact others could
+reuse, and the evidence it had to survive. That changed what the company could pretend not to know.
+A project could not stay alive just because it sounded important. A local fix could not stay
+invisible just because it started small.
 
 Most companies get slower when they raise standards. They get procedural, political, and
 approval-bound. The machine learns to call friction maturity.
@@ -235,9 +216,6 @@ permission systems.
 
 The companies that learn fastest do the opposite. They let local work compete, then discipline the
 market with institutions strong enough to kill what does not earn its place.
-
-When that works, reality leaves marks: owners, reused work, funded bets, dead projects, and
-standards the company had to rewrite. The company learns because truth can change it.
 
 That is the core bet. AI will make attempts cheap. Central planning will try to absorb them. The
 next great companies will make those attempts prove who owns them, what they cost, and what they

--- a/src/_posts/2026-05-25-company-os.md
+++ b/src/_posts/2026-05-25-company-os.md
@@ -7,8 +7,8 @@ permalink: /blog/company-os/
 
 categories: ["Leadership"]
 description:
-  The next great companies will not use AI to make central planning work. They will build free
-  markets inside the company that turn local truth into bids, evidence, owners, and decisions.
+  The next great companies will not use AI to make central planning work. They will turn local truth
+  into bids, evidence, owners, and decisions.
 pull_quote: >
   Use AI to strengthen central planning and the company will look modern while getting slower. Use
   it to make local work compete and the company compounds.
@@ -24,24 +24,23 @@ and people data. A business that finally stops arguing back. The pitch works bec
 real. Each function carries its own map. Meetings sand off the hard parts. Status arrives late,
 pre-defended, and pre-softened.
 
-Central planning feels like relief. That is the trap. Most AI company OS pitches sell a CEO
-dashboard with better autocomplete. They promise a business that can be understood from one seat,
+Central planning feels like relief. That is the trap. Most AI management pitches are just CEO
+dashboards with better autocomplete. They promise a business that can be understood from one seat,
 which usually means a business that has to be changed from one seat too.
 
 Central planning fails at local knowledge, not effort or intelligence. The center can set direction,
 fund the commons, and enforce standards. It cannot know enough, soon enough, to make every useful
 move from above.
 
-This is the free market bet inside a company: local knowledge should become action before it becomes
-a status update.
+This is the bet: local knowledge should become action before it becomes status, and useful action
+should face evidence before it becomes politics.
 
 Use AI to strengthen central planning and the company will look modern while getting slower. Use it
 to make local work compete and the company compounds.
 
-A better operating system does not make headquarters omniscient. It turns local pain into work
-others can pull: a draft, a script, a path, a workflow. Demand finds what is useful. Evidence moves
-capital. That is the company OS worth building: not a prettier permission system, but a way for
-local pain to become institutional change before the organization turns it into status theater.
+A better company does not make headquarters omniscient. It turns local pain into work others can
+pull: a draft, a script, a path, a workflow. Demand finds what is useful. Evidence moves capital.
+Not a prettier permission system. A company that can be changed by the truth it already contains.
 
 ## AI Makes Agency Auditable
 
@@ -55,11 +54,9 @@ a workflow someone else can steal. The person closest to the problem can inspect
 the evidence, write the first version, and make the boundary visible before the next planning
 meeting.
 
-The old excuse was coordination: missing tools, unclear mandate, no time, permission in another
-room. Real constraints still exist: access, time, incentives, authority. AI does not erase those
+The old alibi was coordination: missing tools, unclear mandate, no time, permission in another room.
+Real constraints still exist: access, time, incentives, authority. AI does not erase those
 constraints. It makes the alibi auditable: show the draft, show the attempt, show the boundary.
-
-Not perfectly. Not forever. Enough to expose where the alibi ends.
 
 Inside a company, a bid is not a complaint, a ticket, or a strategy doc. It is an attempt with
 evidence attached: the script, the workflow, the customer path, the boundary hit. AI turns "someone
@@ -67,21 +64,19 @@ should fix this" into "here is the first version, here is what it proves, and he
 broke."
 
 AI can draft the move. It cannot stand behind it. Attempts get cheap; ownership keeps them real. In
-an AI company, the scarce person is not the one who can produce the work. It is the one willing to
-answer for what the work does. If no one will own the consequence, the company should treat the bid
-as noise.
+an AI company, the person who matters is the one willing to answer for what the work does. If no one
+will own the consequence, the company should treat the bid as noise.
 
-Before adding headcount, meetings, platform work, or another operating ritual, the first question
-should be brutal: did a sharp owner with AI hit a real boundary, or did everyone just reach for an
-excuse?
+Before adding headcount, meetings, platform work, or another ritual, the first question should be
+brutal: did a sharp owner with AI hit a real boundary, or did everyone just reach for an excuse?
 
 People owe the company attempts, not just explanations. Leaders owe people access, time, authority,
 and consequence. If they withhold those, they own the bottleneck. Both sides lose the right to hide
 inside ambiguity.
 
 This makes central planning more expensive, not less. Managers who only route permission become
-organizational latency. ICs who only diagnose become exposed. Companies that cannot absorb local
-building turn AI into theater.
+delay. ICs who only diagnose run out of cover. Companies that cannot absorb local building turn AI
+into theater.
 
 If AI gives everyone tools to build and the company still routes every useful move through the
 center, it teaches people to wait. It turns builders into factory workers with better equipment:
@@ -123,32 +118,31 @@ the next person. A bot can answer the question. Gaia makes the answer inheritabl
 Slack is still loud, public, messy, and weirdly efficient at discovery. Gaia matters because useful
 fixes need goods, not just conversation.
 
-That is the alternative to central planning. Useful work has to travel before it is blessed. No
-owner, no adoption path, no evidence, no kill rule: just noise with better mythology.
-
-The market needs rails: a place to make bids, a public trail of who pulled them, an accountable
-owner, a review cadence, kill criteria, and a budget path.
+Work has to travel before it is blessed. No owner, no adoption path, no evidence, no kill rule: just
+noise with better mythology. Markets do not stay honest on their own. They need a place to make
+bids, a public trail of who pulled them, an owner, a review cadence, a kill rule, and a budget path.
 
 ## Free Markets Need Institutions
 
-Without institutions, an internal market does not discover truth; it discovers who can route around
-whom. Enthusiasm passes for demand, prototypes pass for products, Slack praise gets counted as
-adoption, and motion gets mistaken for learning. Assume it will be gamed.
+Free markets inside companies are dangerous. Without institutions, they reward whoever can route
+around whom: charisma passing for demand, demos passing for products, Slack praise passing for
+adoption, motion passing for learning. Assume the market will be gamed. Build until gaming gets
+expensive.
 
-Institutions exist to price what theater avoids: who owns it, who uses it without being begged, what
-it costs, what it replaced, what got worse, and when it dies.
+Not laissez-faire. Attention, ownership, and capital are scarce. Price them with evidence, or
+pretend the center can see every bruise first. Institutions price what theater avoids: who owns it,
+who uses it, what it costs, what got worse, and when it dies.
 
 The currency is not enthusiasm. It is pulled usage, owner time, budget, reduced pain, and changed
 behavior. Praise is not demand. A project with no owner is not a bet. A tool that saves one team by
 pushing its cost onto three others has not cleared the market. It has exported pain.
 
-The system has to make truth-seeking cheaper than the political move: show the evidence, name the
+The company has to make truth-seeking cheaper than the political move: show the evidence, name the
 owner, price the risk, and make polished theater too heavy to carry.
 
-At GrowthLoop, Gaia and Grimoire carry that bargain together. Gaia creates supply: local work can
-appear, spread, mutate, and become shared machinery. Grimoire prices consequence: work becomes
-visible, owned, reviewed, funded, killed, and remembered. Pain becomes a version others can use; use
-creates evidence.
+At GrowthLoop, Gaia and Grimoire split the job. Gaia lets local work appear, spread, mutate, and
+become shared machinery. Grimoire makes that work visible, owned, reviewed, funded, killed, and
+remembered. Pain becomes a version others can use; use creates evidence.
 
 Every six weeks, Grimoire turns the portfolio into a docket: owners, movement, stalls, costs,
 evidence, and what changed. The owner has to stand in public with the facts while there is still
@@ -162,19 +156,19 @@ So the company moved capital. We killed most of those bets, moved people to bett
 the standard explicit: a lead is not done when they report resistance. They are accountable for
 turning resistance into a decision.
 
-That is the [directed chaos](/blog/directed-chaos/) bargain: people can build for themselves because
-the work still has to face the institution. Local work earns freedom by facing standards before it
-becomes politics.
+That is the [directed chaos](/blog/directed-chaos/) bargain: build locally, face standards publicly,
+and let the institution decide what survives.
 
 ## Founder Power Must Leave Artifacts
 
 The point is not to abolish the center. Some bets still belong there: strategy, taste, culture,
 standards, incentives, safety, budgets, existential risk, and the commons no local team would fund
-early enough.
+early enough. A market inside a company is not the absence of power. It is a way to make power
+answer to evidence.
 
-Founder power is real because some bets have no natural owner yet. Founders can absorb risk, spend
-trust, fund the commons, and say, "We are moving now," when local evidence is still too early to
-price.
+Founder power belongs here too. Some bets have no natural owner yet. Founders can absorb risk, spend
+trust, fund the commons, and say, "We are moving now," before the market has enough evidence to
+price the move.
 
 Those are war powers. Use them. The failure is when the emergency becomes the constitution.
 
@@ -185,17 +179,17 @@ was one of those founder bets: too early for any local team to justify, importan
 center to fund anyway. It gave the company a name and funding path for the category, then forced the
 bet back through standards, ownership, and consequence.
 
-That power earns its place only when it comes back with receipts: the risk named, the owner
-assigned, the budget visible, the kill criteria stated, the review date set, the standard changed.
-Founder intervention becomes central planning when it is constant, hidden, or detached from local
-evidence. Intervene loudly, own the bet, make the cost visible. The best use of concentrated power
-is to make more of the company powerful.
+That power earns its place only when it comes back with receipts: risk named, owner assigned, budget
+visible, kill criteria stated, review date set. Founder intervention becomes central planning when
+it is constant, hidden, or detached from local evidence. Intervene loudly, own the bet, make the
+cost visible. The best use of concentrated power is to make more of the company powerful.
 
 Power does not get better by pretending it is harmless. It gets better when reality has enough
 [independent paths](https://blog.cosmos-institute.org/p/when-decentralization-fails) back into the
 room that power cannot quietly grade its own work.
 
-Let the market discover. Let the center decide when it must. Make both answer to reality.
+The market should discover. Leaders should intervene when they must. Both should have to answer to
+evidence.
 
 ## The Tradeoff Broke
 
@@ -203,13 +197,13 @@ A year ago, we were not moving fast enough for the bets we wanted to win. But ra
 cheap to fake and easy to distrust. The test was whether we could raise standards, lower incident
 pressure, hold ownership, and still move faster.
 
-Quality moved first. Early in this journey, we called a platform stability Code Red because the
-system was moving faster than its guardrails. That was central power doing its job: stopping the
-room, naming the cost, and making the problem impossible to route around.
+Quality moved first. Early in this journey, we called a platform stability Code Red because we were
+moving faster than our guardrails. That was central power doing its job: stopping the room, naming
+the cost, and making the problem impossible to route around.
 
-Then the numbers moved in the harder direction. High-urgency incidents were cut in half. Resolution
-time fell from four days to less than one. Pager acknowledgements went from a coin flip to nearly
-automatic. The system was not hiding pain. It was getting better at forcing pain into the open.
+Then the numbers moved the right way. High-urgency incidents were cut in half. Resolution time fell
+from four days to less than one. Pager acknowledgements went from a coin flip to nearly automatic.
+Pain was becoming harder to hide and faster to fix.
 
 Ownership held. The extra work still attached to real projects instead of drifting into clever,
 ownerless churn. More output is not progress if nobody can explain what bet it serves.
@@ -229,9 +223,9 @@ A local fix could not stay invisible just because it started small.
 Most companies get slower when they raise standards. They get procedural, political, and
 approval-bound. The machine learns to call friction maturity.
 
-We got faster because AI made local work cheaper to package, ship, and reuse, and the operating
-system gave it a path: Gaia for supply, Grimoire for ownership and consequence, the center for bets
-the market could not yet price.
+We got faster because AI made local work cheaper to package, ship, and reuse, and the company gave
+that work a path: Gaia for supply, Grimoire for ownership and consequence, the center for bets the
+market could not yet price.
 
 ## The Company Learns
 
@@ -239,15 +233,14 @@ AI will flood companies with local attempts. Most organizations will respond by 
 central planning: more dashboards, more approvals, more executive synthesis, more beautiful
 permission systems.
 
-The better company does the opposite. It builds a market for local work, then disciplines that
+The companies that learn fastest do the opposite. They let local work compete, then discipline the
 market with institutions strong enough to kill what does not earn its place.
 
-When the system works, reality leaves marks: owners, reusable work, funded bets, dead projects, and
-standards the company had to rewrite. That takes leaders willing to spend power on people who need
-less permission.
+When that works, reality leaves marks: owners, reused work, funded bets, dead projects, and
+standards the company had to rewrite. The company learns because truth can change it.
 
-That is the core bet. AI will make local attempts cheap. Central planning will try to absorb them
-into dashboards. The next great companies will do something harder: turn attempts into evidence,
-evidence into ownership, and ownership into decisions.
+That is the core bet. AI will make attempts cheap. Central planning will try to absorb them. The
+next great companies will make those attempts prove who owns them, what they cost, and what they
+change.
 
 The company that wins is not the one that sees more. It is the one that makes truth consequential.

--- a/src/_posts/2026-05-25-company-os.md
+++ b/src/_posts/2026-05-25-company-os.md
@@ -153,10 +153,10 @@ and let the institution decide what survives.
 
 ## The Tradeoff Broke
 
-The bet was exactly that markets inside the company would make us more entrepreneurial without
-making us sloppier. A year ago, we were not moving fast enough for the bets we wanted to win. But
-raw throughput is cheap to fake and easy to distrust. What mattered was whether we could raise
-standards, lower incident pressure, hold ownership, and still move faster.
+The bet was that the old tradeoff was fake: more local motion did not have to mean more damage. A
+year ago, we were not moving fast enough for the bets we wanted to win. But raw throughput is cheap
+to fake and easy to distrust. What mattered was whether we could raise standards, lower incident
+pressure, hold ownership, and still move faster.
 
 Quality moved first. We called a platform stability Code Red because we were moving faster than our
 guardrails. That was central power doing its job: stopping the room, naming the cost, and making the


### PR DESCRIPTION
## Summary
- Reframe the essay around the stronger company/free-market thesis
- Remove body copy references to the older company OS framing while leaving the URL unchanged
- Tighten repetition and cadence after the reframing pass

## Validation
- `mise run lint -a`
- `mise run build`